### PR TITLE
Fix hard-coded href path to "/route/second"

### DIFF
--- a/route/templates/route/main.html
+++ b/route/templates/route/main.html
@@ -1,7 +1,7 @@
 <h1>Using the url tag</h2>
 <ul>
     <li>
-        <a href="/route/second-view">
+        <a href="/route/second">
         hard-coded</a> (not DRY)
     </li>
     <li>


### PR DESCRIPTION
Hard-coded "/route/second-view" points nowhere. Path "/route/second" works.