### PR TITLE
Fix count displayed in sessfun view of session app

### DIFF
--- a/session/views.py
+++ b/session/views.py
@@ -20,7 +20,9 @@ def cookie(request):
 
 def sessfun(request) :
     num_visits = request.session.get('num_visits', 0) + 1
-    request.session['num_visits'] = num_visits 
-    if num_visits > 4 : del(request.session['num_visits'])
+    if num_visits > 4 :
+        del(request.session['num_visits'])
+        num_visits = 1  # After the fourth visit, the value resets to 1
+    request.session['num_visits'] = num_visits
     return HttpResponse('view count='+str(num_visits))
 


### PR DESCRIPTION
In the Lecture **Django Sessions** of the **Week 1** of the **Django Features and Libraries** course in **Coursera**, it is explained that the counter goes from _1 to 4_, but it actually goes from _1 to 5_, since the variable `num_visits` is not reset after deleting `request.session['num_visits']`, thus displaying the number 5, when it should be 1.

Resetting the variable `num_visits` inside the `if` condition does the trick:

```python
if num_visits > 4 :
    del(request.session['num_visits'])
    num_visits = 1  # After the fourth visit, the value resets to 1
# ...
```