### PR TITLE
align sample repo with correct urls comment

### DIFF
--- a/dj4e-samples/urls.py
+++ b/dj4e-samples/urls.py
@@ -22,10 +22,11 @@ from django.views.static import serve
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    path('', include('home.urls')),  # Change to ads.urls
+    path('', include('home.urls')),  # Keep
     path('admin/', admin.site.urls),  # Keep
     path('accounts/', include('django.contrib.auth.urls')),  # Keep
     re_path(r'^oauth/', include('social_django.urls', namespace='social')),  # Keep
+    # Add new path for ads.urls
 
     # Sample applications
     path('hello/', include('hello.urls')),


### PR DESCRIPTION
The tutorial uses the base home path template to show the ads application. The comments weren't aligned. Proposing a change to align the same