### PR TITLE
Updated to lit3.

### DIFF
--- a/site/wc/dj4e-favstar.js
+++ b/site/wc/dj4e-favstar.js
@@ -1,34 +1,24 @@
-import {html, css, LitElement} from 'https://cdn.jsdelivr.net/gh/lit/dist@2.4.0/core/lit-core.min.js';
+import { html, LitElement } from "https://cdn.jsdelivr.net/npm/lit@3.2.1/+esm";
 
 // https://stackoverflow.com/questions/68614776/using-lit-with-javascript-and-no-build-tools
 
 export class DJ4EFavoriteStar extends LitElement {
 
-  static get properties() {
-    return {
-      fav: {type: String}
-    }
-  }
-
-  constructor() {
-    super();
-    this.fav = false;
-  }
+  static properties = {
+    fav: { type: Boolean },
+  };
 
   // Don't use Shadow-DOM 
-  createRenderRoot() { return this;}
+  createRenderRoot() { return this; }
 
   render() {
-    return this.fav == 'true'
-    ? html`<span class="fa-stack" style="vertical-align: middle;">
-        <i class="fa fa-star fa-stack-1x" style="color: orange;"></i>
+
+    return html`
+      <span class="fa-stack" style="vertical-align: middle;">
+        <i class="fa fa-star fa-stack-1x" style="${this.fav ? "" : "display: none;"} color: orange;"></i>
         <i class="fa fa-star-o fa-stack-1x"></i>
-        </span>`
-    : html`<span class="fa-stack" style="vertical-align: middle;">
-        <i class="fa fa-star fa-stack-1x" style="display: none; color: orange;"></i>
-        <i class="fa fa-star-o fa-stack-1x"></i>
-        </span>`
-    ;
+      </span>
+    ;`
   }
 }
 

--- a/site/wc/dj4e-greet.js
+++ b/site/wc/dj4e-greet.js
@@ -1,14 +1,12 @@
-import {html, css, LitElement} from 'https://cdn.jsdelivr.net/gh/lit/dist@2.4.0/core/lit-core.min.js';
+import { html, LitElement } from "https://cdn.jsdelivr.net/npm/lit@3.2.1/+esm";
 
 // https://stackoverflow.com/questions/68614776/using-lit-with-javascript-and-no-build-tools
 
 export class SimpleGreeting extends LitElement {
 
-  static get properties() {
-    return {
-      name: {type: String}
-    }
-  }
+  static properties =  {
+    name: { type: String }
+  };
 
   constructor() {
     super();

--- a/site/wc/index.html
+++ b/site/wc/index.html
@@ -7,8 +7,8 @@
 <ul>
     <li>dj4e-greeting: <dj4e-greeting name="World"></dj4e-greeting></li>
     <li>idj4e-favstar:
-        <dj4e-favstar fav="true"></dj4e-favstar>
-        <dj4e-favstar fav="false"></dj4e-favstar>
+        <dj4e-favstar fav></dj4e-favstar>
+        <dj4e-favstar></dj4e-favstar>
     </li>
 </ul>
 


### PR DESCRIPTION
properties don't need to be defined as functions any longer, just an object literal will do. Boolean attributes (fav) shouldn't be cast about into different types if you can help it. Also, boolean attributes don't need a string value like "true". They're either there or they're not. I simplified the render method to not be as repetitive. You can use the variable in a js expression to modify the single template output. If you update "fav" on the tag, Lit will just rerender the bare minimum it needs to as it understands the template parts.